### PR TITLE
Error catching for plotting

### DIFF
--- a/@conZono/plotConZono1D.m
+++ b/@conZono/plotConZono1D.m
@@ -22,16 +22,39 @@ beq = [obj.b];
 lb = -ones(obj.nG,1);
 ub =  ones(obj.nG,1);
 
-dir = 1; % Find upper bound
-[x,~,~] = solveLP(dir*obj.G,[],[],Aeq,beq,lb,ub,optSolver);
-extreme = [obj.G*x + obj.c]';
-v(1,:) = [extreme 0];
+try
+    dir = 1; % Find upper bound
+    %[x,~,~] = solveLP(dir*obj.G,[],[],Aeq,beq,lb,ub,optSolver);
+    x = findVertex(dir,obj.G,Aeq,beq,lb,ub,optSolver);
+    extreme = [obj.G*x + obj.c]';
+    v(1,:) = [extreme 0];
 
-dir = -1; % Find lower bound
-[x,~,~] = solveLP(dir*obj.G,[],[],Aeq,beq,lb,ub,optSolver);
-extreme = [obj.G*x + obj.c]';
-v(2,:) = [extreme 0];
+    dir = -1; % Find lower bound
+    %[x,~,~] = solveLP(dir*obj.G,[],[],Aeq,beq,lb,ub,optSolver);
+    x = findVertex(dir,obj.G,Aeq,beq,lb,ub,optSolver);
+    extreme = [obj.G*x + obj.c]';
+    v(2,:) = [extreme 0];
 
-f = [1 2];
+    f = [1 2];
+catch E
+    if strcmp(E.identifier, 'PlotError:VertexNotFound')
+        if checkEmpty(conZono(obj.G,obj.c,Aeq,beq))
+            warning('zonoLAB:EmptyZonotope','Constrained zonotope is empty and cannot be plotted.')
+            v = []; f = [];
+            return
+        end
+        rethrow(E);
+    else
+        rethrow(E);
+    end
+end
 
+end
+
+% Local functions
+function [x] = findVertex(dir,G,Aeq,beq,lb,ub,optSolver)
+    [x,~,~] = solveLP(dir*G,[],[],Aeq,beq,lb,ub,optSolver);
+    if isnan(x)
+        error('PlotError:VertexNotFound','Could not find a solution for a vertex while plotting')
+    end
 end

--- a/@conZono/plotConZono2D.m
+++ b/@conZono/plotConZono2D.m
@@ -22,156 +22,183 @@ beq = [obj.b];
 lb = -ones(obj.nG,1);
 ub =  ones(obj.nG,1);
 
-% Find first vertex
-dir = [1 0];
-searchedDirs(1,:) = normalize(dir,'norm');
-[x,~,~] = solveLP(dir*obj.G,[],[],Aeq,beq,lb,ub,optSolver);
-foundVerts(1,:) = [obj.G*x + obj.c]';
-
-% Find second (opposite) vertex
-dir = [-1 0];
-searchedDirs(2,:) = normalize(dir,'norm');
-[x,~,~] = solveLP(dir*obj.G,[],[],Aeq,beq,lb,ub,optSolver);
-foundVerts(2,:) = [obj.G*x + obj.c]';
-
-if (foundVerts(1,:)-foundVerts(2,:) <= 1e-12) % Same vertex
+try
     % Find first vertex
-    dir = [0 1];
+    dir = [1 0];
     searchedDirs(1,:) = normalize(dir,'norm');
-    [x,~,~] = solveLP(dir*obj.G,[],[],Aeq,beq,lb,ub,optSolver);
+    %[x,~,~] = solveLP(dir*obj.G,[],[],Aeq,beq,lb,ub,optSolver);
+    x = findVertex(dir,obj.G,Aeq,beq,lb,ub,optSolver);
     foundVerts(1,:) = [obj.G*x + obj.c]';
-
+    
     % Find second (opposite) vertex
-    dir = [0 -1];
+    dir = [-1 0];
     searchedDirs(2,:) = normalize(dir,'norm');
-    [x,~,~] = solveLP(dir*obj.G,[],[],Aeq,beq,lb,ub,optSolver);
+    %[x,~,~] = solveLP(dir*obj.G,[],[],Aeq,beq,lb,ub,optSolver);
+    x = findVertex(dir,obj.G,Aeq,beq,lb,ub,optSolver);
     foundVerts(2,:) = [obj.G*x + obj.c]';
-end
-
-if (foundVerts(1,:)-foundVerts(2,:) <= 1e-12) % Single point
-    v = foundVerts(1,:);
-    f = 1;
-    return
-end
-
-% Continue if set is not a single point
-vertDiff = foundVerts(1,:) - foundVerts(2,:);
-dir = [-vertDiff(2) vertDiff(1)];
-[x,~,~] = solveLP(dir*obj.G,[],[],Aeq,beq,lb,ub,optSolver);
-extreme = [obj.G*x + obj.c]';
-isNewVert(1) = dir*extreme' >= 1e-6;                        % Tolerance
-dir = -dir;
-[x,~,~] = solveLP(dir*obj.G,[],[],Aeq,beq,lb,ub,optSolver);
-extreme = [obj.G*x + obj.c]';
-isNewVert(2) = dir*extreme' >= 1e-6;                        % Tolerance
-if max(isNewVert) == 0  % A line segment in 2D
-    v = foundVerts;
-    f = [1 2];
-    return
-end
-
-% Continue if set is not a line segment in 2D
-firstVert = foundVerts(1,:);
-endVert = foundVerts(2,:);
-% Compute center
-centerVert = (firstVert + endVert)/2;
-% Compute vertex angles
-vertDiff = firstVert - centerVert;
-referenceAngle = atan2(vertDiff(:,2),vertDiff(:,1));
-foundVertDirs(1) = 0;
-% Farthest CW vert
-foundVertDirs(2) = -pi;
-treeStruct(1,3) = 2;
-treeStruct(2,:) = [1 zeros(1,2)];
-% Farthest CW vert
-foundVerts(3,:) = endVert;
-foundVertDirs(3) = pi;
-treeStruct(1,2) = 3;
-treeStruct(3,:) = [1 zeros(1,2)];
-% Initialize number of vertices
-nVerts = 3;
-% Order the vertices
-[vertOrder,~] = listInOrder(treeStruct,1,zeros(nVerts,1),1);
-% Find the remaining vertices
-maxIter = 1e6;                                              % Maximium iterations
-indx = 1;
-for i = 1:maxIter
-    vertA = foundVerts(vertOrder(indx),:);
-    vertB = foundVerts(vertOrder(indx+1),:);
-    vertDiff = vertA - vertB;
-    dir = normalize(-[-vertDiff(2) vertDiff(1)],'norm');
-    [x,~,~] = solveLP(dir*obj.G,[],[],Aeq,beq,lb,ub,optSolver);
+    
+    if (foundVerts(1,:)-foundVerts(2,:) <= 1e-12) % Same vertex
+        % Find first vertex
+        dir = [0 1];
+        searchedDirs(1,:) = normalize(dir,'norm');
+        %[x,~,~] = solveLP(dir*obj.G,[],[],Aeq,beq,lb,ub,optSolver);
+        x = findVertex(dir,obj.G,Aeq,beq,lb,ub,optSolver);
+        foundVerts(1,:) = [obj.G*x + obj.c]';
+    
+        % Find second (opposite) vertex
+        dir = [0 -1];
+        searchedDirs(2,:) = normalize(dir,'norm');
+        %[x,~,~] = solveLP(dir*obj.G,[],[],Aeq,beq,lb,ub,optSolver);
+        x = findVertex(dir,obj.G,Aeq,beq,lb,ub,optSolver);
+        foundVerts(2,:) = [obj.G*x + obj.c]';
+    end
+    
+    if (foundVerts(1,:)-foundVerts(2,:) <= 1e-12) % Single point
+        v = foundVerts(1,:);
+        f = 1;
+        return
+    end
+    
+    % Continue if set is not a single point
+    vertDiff = foundVerts(1,:) - foundVerts(2,:);
+    dir = [-vertDiff(2) vertDiff(1)];
+    %[x,~,~] = solveLP(dir*obj.G,[],[],Aeq,beq,lb,ub,optSolver);
+    x = findVertex(dir,obj.G,Aeq,beq,lb,ub,optSolver);
     extreme = [obj.G*x + obj.c]';
-    isNew = min(dir*extreme'-dir*foundVerts(vertOrder(indx:indx+1),:)' > 10^-6) == 1; % Tolerance
-    if isNew
-        nVerts = nVerts + 1;
-        foundVerts(nVerts,:) = extreme;
-        if treeStruct(vertOrder(indx),3) == 0
-            treeStruct(vertOrder(indx),3) = nVerts;
-            treeStruct(nVerts,:) = [vertOrder(indx) 0 0];
+    isNewVert(1) = dir*extreme' >= 1e-6;                        % Tolerance
+    dir = -dir;
+    %[x,~,~] = solveLP(dir*obj.G,[],[],Aeq,beq,lb,ub,optSolver);
+    x = findVertex(dir,obj.G,Aeq,beq,lb,ub,optSolver);
+    extreme = [obj.G*x + obj.c]';
+    isNewVert(2) = dir*extreme' >= 1e-6;                        % Tolerance
+    if max(isNewVert) == 0  % A line segment in 2D
+        v = foundVerts;
+        f = [1 2];
+        return
+    end
+    
+    % Continue if set is not a line segment in 2D
+    firstVert = foundVerts(1,:);
+    endVert = foundVerts(2,:);
+    % Compute center
+    centerVert = (firstVert + endVert)/2;
+    % Compute vertex angles
+    vertDiff = firstVert - centerVert;
+    referenceAngle = atan2(vertDiff(:,2),vertDiff(:,1));
+    foundVertDirs(1) = 0;
+    % Farthest CW vert
+    foundVertDirs(2) = -pi;
+    treeStruct(1,3) = 2;
+    treeStruct(2,:) = [1 zeros(1,2)];
+    % Farthest CW vert
+    foundVerts(3,:) = endVert;
+    foundVertDirs(3) = pi;
+    treeStruct(1,2) = 3;
+    treeStruct(3,:) = [1 zeros(1,2)];
+    % Initialize number of vertices
+    nVerts = 3;
+    % Order the vertices
+    [vertOrder,~] = listInOrder(treeStruct,1,zeros(nVerts,1),1);
+    % Find the remaining vertices
+    maxIter = 1e6;                                              % Maximium iterations
+    indx = 1;
+    for i = 1:maxIter
+        vertA = foundVerts(vertOrder(indx),:);
+        vertB = foundVerts(vertOrder(indx+1),:);
+        vertDiff = vertA - vertB;
+        dir = normalize(-[-vertDiff(2) vertDiff(1)],'norm');
+        %[x,~,~] = solveLP(dir*obj.G,[],[],Aeq,beq,lb,ub,optSolver);
+        x = findVertex(dir,obj.G,Aeq,beq,lb,ub,optSolver);
+        extreme = [obj.G*x + obj.c]';
+        isNew = min(dir*extreme'-dir*foundVerts(vertOrder(indx:indx+1),:)' > 10^-6) == 1; % Tolerance
+        if isNew
+            nVerts = nVerts + 1;
+            foundVerts(nVerts,:) = extreme;
+            if treeStruct(vertOrder(indx),3) == 0
+                treeStruct(vertOrder(indx),3) = nVerts;
+                treeStruct(nVerts,:) = [vertOrder(indx) 0 0];
+            else
+                treeStruct(vertOrder(indx+1),2) = nVerts;
+                treeStruct(nVerts,:) = [vertOrder(indx+1) 0 0];
+            end
+            [vertOrder,~] = listInOrder(treeStruct,1,zeros(nVerts,1),1);
         else
-            treeStruct(vertOrder(indx+1),2) = nVerts;
-            treeStruct(nVerts,:) = [vertOrder(indx+1) 0 0];
-        end
-        [vertOrder,~] = listInOrder(treeStruct,1,zeros(nVerts,1),1);
-    else
-        if vertOrder(indx+1) == 2
-            break
-        else
-            indx = indx + 1;
+            if vertOrder(indx+1) == 2
+                break
+            else
+                indx = indx + 1;
+            end
         end
     end
+    
+    % for i = 1:maxIter
+    %     vertA = foundVerts(vertOrder(indx),:);
+    %     vertB = foundVerts(vertOrder(indx+1),:);
+    %     vertDiff = vertA - vertB;
+    %     dir = -[-vertDiff(2) vertDiff(1)];
+    %     isNewdir = min(sum(abs(normalize(dir,'norm')-searchedDirs),2))>=1e-6;   % Tolerance
+    %     if isNewdir
+    %         searchedDirs = [searchedDirs;normalize(dir,'norm')];                % Growing list
+    %         [x,~,~] = solveLP(normalize(dir,'norm')*obj.G,[],[],Aeq,beq,lb,ub,optSolver);
+    %         extreme = [obj.G*x + obj.c]';
+    %         vertDiffs = extreme - centerVert;
+    %         vertAngle = atan2(vertDiffs(:,2),vertDiffs(:,1));
+    %         newVertDir = vertAngle-referenceAngle;
+    %         newVertDir(newVertDir<-pi) = newVertDir(newVertDir<-pi) + 2*pi;
+    %         newVertDir(newVertDir>pi) = newVertDir(newVertDir>pi) - 2*pi;
+    %         orderDirs = foundVertDirs(vertOrder);
+    %         isNew = min(abs(newVertDir-orderDirs))>=1e-6;                   % Tolerance
+    %     else
+    %         isNew = 0;
+    %     end
+    %     if isNew
+    %         nVerts = nVerts + 1;
+    %         foundVerts(nVerts,:) = extreme;
+    %         foundVertDirs(nVerts) = newVertDir;
+    %         if treeStruct(vertOrder(indx),3) == 0
+    %             treeStruct(vertOrder(indx),3) = nVerts;
+    %             treeStruct(nVerts,:) = [vertOrder(indx) 0 0];
+    %         else
+    %             treeStruct(vertOrder(indx+1),2) = nVerts;
+    %             treeStruct(nVerts,:) = [vertOrder(indx+1) 0 0];
+    %         end
+    %         [vertOrder,~] = listInOrder(treeStruct,1,zeros(nVerts,1),1);
+    %     else
+    %         if vertOrder(indx+1) == 2
+    %             break
+    %         else
+    %             indx = indx + 1;
+    %         end
+    %     end
+    % end
+    
+    nVerts = nVerts - 1; % Added to remove extra vertex
+    v = foundVerts(vertOrder,:);
+    v = v(1:end-1,:); % Added to remove extra vertex
+    f = [1:nVerts];
+catch E
+    if strcmp(E.identifier, 'PlotError:VertexNotFound')
+        if checkEmpty(conZono(obj.G,obj.c,Aeq,beq))
+            warning('zonoLAB:EmptyZonotope','Constrained zonotope is empty and cannot be plotted.')
+            v = []; f = [];
+            return
+        end
+        rethrow(E);
+    else
+        rethrow(E);
+    end
 end
-
-% for i = 1:maxIter
-%     vertA = foundVerts(vertOrder(indx),:);
-%     vertB = foundVerts(vertOrder(indx+1),:);
-%     vertDiff = vertA - vertB;
-%     dir = -[-vertDiff(2) vertDiff(1)];
-%     isNewdir = min(sum(abs(normalize(dir,'norm')-searchedDirs),2))>=1e-6;   % Tolerance
-%     if isNewdir
-%         searchedDirs = [searchedDirs;normalize(dir,'norm')];                % Growing list
-%         [x,~,~] = solveLP(normalize(dir,'norm')*obj.G,[],[],Aeq,beq,lb,ub,optSolver);
-%         extreme = [obj.G*x + obj.c]';
-%         vertDiffs = extreme - centerVert;
-%         vertAngle = atan2(vertDiffs(:,2),vertDiffs(:,1));
-%         newVertDir = vertAngle-referenceAngle;
-%         newVertDir(newVertDir<-pi) = newVertDir(newVertDir<-pi) + 2*pi;
-%         newVertDir(newVertDir>pi) = newVertDir(newVertDir>pi) - 2*pi;
-%         orderDirs = foundVertDirs(vertOrder);
-%         isNew = min(abs(newVertDir-orderDirs))>=1e-6;                   % Tolerance
-%     else
-%         isNew = 0;
-%     end
-%     if isNew
-%         nVerts = nVerts + 1;
-%         foundVerts(nVerts,:) = extreme;
-%         foundVertDirs(nVerts) = newVertDir;
-%         if treeStruct(vertOrder(indx),3) == 0
-%             treeStruct(vertOrder(indx),3) = nVerts;
-%             treeStruct(nVerts,:) = [vertOrder(indx) 0 0];
-%         else
-%             treeStruct(vertOrder(indx+1),2) = nVerts;
-%             treeStruct(nVerts,:) = [vertOrder(indx+1) 0 0];
-%         end
-%         [vertOrder,~] = listInOrder(treeStruct,1,zeros(nVerts,1),1);
-%     else
-%         if vertOrder(indx+1) == 2
-%             break
-%         else
-%             indx = indx + 1;
-%         end
-%     end
-% end
-
-nVerts = nVerts - 1; % Added to remove extra vertex
-v = foundVerts(vertOrder,:);
-v = v(1:end-1,:); % Added to remove extra vertex
-f = [1:nVerts];
 
 end
 
 % Local functions
+function [x] = findVertex(dir,G,Aeq,beq,lb,ub,optSolver)
+    [x,~,~] = solveLP(dir*G,[],[],Aeq,beq,lb,ub,optSolver);
+    if isnan(x)
+        error('PlotError:VertexNotFound','Could not find a solution for a vertex while plotting')
+    end
+end
+
 function [vertOrder,indx] = listInOrder(treeStruct,row,vertOrder,indx)
     if treeStruct(row,2) ~= 0
         [vertOrder,indx] = listInOrder(treeStruct,treeStruct(row,2),vertOrder,indx);

--- a/@conZono/plotConZono3D.m
+++ b/@conZono/plotConZono3D.m
@@ -24,188 +24,219 @@ beq = [obj.b];
 lb = -ones(obj.nG,1);
 ub =  ones(obj.nG,1);
 
-% Find first vertex
-dir = [1 0 0];
-searchedDirs(1,:) = normalize(dir,'norm');
-[x,~,~] = solveLP(dir*obj.G,[],[],Aeq,beq,lb,ub,optSolver);
-foundVerts(1,:) = [obj.G*x + obj.c]';
-
-% Find second (opposite) vertex
-dir = [-1 0 0];
-searchedDirs(2,:) = normalize(dir,'norm');
-[x,~,~] = solveLP(dir*obj.G,[],[],Aeq,beq,lb,ub,optSolver);
-foundVerts(2,:) = [obj.G*x + obj.c]';
-
-if (foundVerts(1,:)-foundVerts(2,:) <= 1e-12) % Same vertex
+try
     % Find first vertex
-    dir = [0 1 0];
+    dir = [1 0 0];
     searchedDirs(1,:) = normalize(dir,'norm');
-    [x,~,~] = solveLP(dir*obj.G,[],[],Aeq,beq,lb,ub,optSolver);
+    %[x,~,~] = solveLP(dir*obj.G,[],[],Aeq,beq,lb,ub,optSolver);
+    x = findVertex(dir,obj.G,Aeq,beq,lb,ub,optSolver);
     foundVerts(1,:) = [obj.G*x + obj.c]';
 
     % Find second (opposite) vertex
-    dir = [0 -1 0];
+    dir = [-1 0 0];
     searchedDirs(2,:) = normalize(dir,'norm');
-    [x,~,~] = solveLP(dir*obj.G,[],[],Aeq,beq,lb,ub,optSolver);
+    %[x,~,~] = solveLP(dir*obj.G,[],[],Aeq,beq,lb,ub,optSolver);
+    x = findVertex(dir,obj.G,Aeq,beq,lb,ub,optSolver);
     foundVerts(2,:) = [obj.G*x + obj.c]';
-end
 
-if (foundVerts(1,:)-foundVerts(2,:) <= 1e-12) % Same vertex
-    % Find first vertex
-    dir = [0 0 1];
-    searchedDirs(1,:) = normalize(dir,'norm');
-    [x,~,~] = solveLP(dir*obj.G,[],[],Aeq,beq,lb,ub,optSolver);
-    foundVerts(1,:) = [obj.G*x + obj.c]';
+    if (foundVerts(1,:)-foundVerts(2,:) <= 1e-12) % Same vertex
+        % Find first vertex
+        dir = [0 1 0];
+        searchedDirs(1,:) = normalize(dir,'norm');
+        %[x,~,~] = solveLP(dir*obj.G,[],[],Aeq,beq,lb,ub,optSolver);
+        x = findVertex(dir,obj.G,Aeq,beq,lb,ub,optSolver);
+        foundVerts(1,:) = [obj.G*x + obj.c]';
 
-    % Find second (opposite) vertex
-    dir = [0 0 -1];
-    searchedDirs(2,:) = normalize(dir,'norm');
-    [x,~,~] = solveLP(dir*obj.G,[],[],Aeq,beq,lb,ub,optSolver);
-    foundVerts(2,:) = [obj.G*x + obj.c]';
-end
+        % Find second (opposite) vertex
+        dir = [0 -1 0];
+        searchedDirs(2,:) = normalize(dir,'norm');
+        %[x,~,~] = solveLP(dir*obj.G,[],[],Aeq,beq,lb,ub,optSolver);
+        x = findVertex(dir,obj.G,Aeq,beq,lb,ub,optSolver);
+        foundVerts(2,:) = [obj.G*x + obj.c]';
+    end
+
+    if (foundVerts(1,:)-foundVerts(2,:) <= 1e-12) % Same vertex
+        % Find first vertex
+        dir = [0 0 1];
+        searchedDirs(1,:) = normalize(dir,'norm');
+        %[x,~,~] = solveLP(dir*obj.G,[],[],Aeq,beq,lb,ub,optSolver);
+        x = findVertex(dir,obj.G,Aeq,beq,lb,ub,optSolver);
+        foundVerts(1,:) = [obj.G*x + obj.c]';
+
+        % Find second (opposite) vertex
+        dir = [0 0 -1];
+        searchedDirs(2,:) = normalize(dir,'norm');
+        %[x,~,~] = solveLP(dir*obj.G,[],[],Aeq,beq,lb,ub,optSolver);
+        x = findVertex(dir,obj.G,Aeq,beq,lb,ub,optSolver);
+        foundVerts(2,:) = [obj.G*x + obj.c]';
+    end
 
 
-if (foundVerts(1,:)-foundVerts(2,:) <= 1e-12) % Single point
-    v = foundVerts(1,:);
-    f = 1;
-    return
-end
+    if (foundVerts(1,:)-foundVerts(2,:) <= 1e-12) % Single point
+        v = foundVerts(1,:);
+        f = 1;
+        return
+    end
 
-% Continue if set is not a single point
-% Find 3rd vertex
-nullDirs = null(foundVerts(1,:)-foundVerts(2,:))';
-dir = nullDirs(1,:);
-[x,~,~] = solveLP(dir*obj.G,[],[],Aeq,beq,lb,ub,optSolver);
-extreme(1,:) = [obj.G*x + obj.c]';
-isNewVert(1) = sum(abs(nullDirs*(extreme(1,:)-foundVerts(1,:))'))>=1e-6;           % Tolerance
-dir = -dir;
-[x,~,~] = solveLP(dir*obj.G,[],[],Aeq,beq,lb,ub,optSolver);
-extreme(2,:) = [obj.G*x + obj.c]';
-isNewVert(2) = sum(abs(nullDirs*(extreme(2,:)-foundVerts(1,:))'))>=1e-6;           % Tolerance
-dir = nullDirs(2,:);
-[x,~,~] = solveLP(dir*obj.G,[],[],Aeq,beq,lb,ub,optSolver);
-extreme(3,:) = [obj.G*x + obj.c]';
-isNewVert(3) = sum(abs(nullDirs*(extreme(3,:)-foundVerts(1,:))'))>=1e-6;           % Tolerance
-dir = -dir;
-[x,~,~] = solveLP(dir*obj.G,[],[],Aeq,beq,lb,ub,optSolver);
-extreme(4,:) = [obj.G*x + obj.c]';
-isNewVert(4) = sum(abs(nullDirs*(extreme(4,:)-foundVerts(1,:))'))>=1e-6;           % Tolerance
-if max(isNewVert) == 0  % A line segment in 3D
-    v = foundVerts;
-    f = [1 2];
-    return
-end
+    % Continue if set is not a single point
+    % Find 3rd vertex
+    nullDirs = null(foundVerts(1,:)-foundVerts(2,:))';
+    dir = nullDirs(1,:);
+    %[x,~,~] = solveLP(dir*obj.G,[],[],Aeq,beq,lb,ub,optSolver);
+    x = findVertex(dir,obj.G,Aeq,beq,lb,ub,optSolver);
+    extreme(1,:) = [obj.G*x + obj.c]';
+    isNewVert(1) = sum(abs(nullDirs*(extreme(1,:)-foundVerts(1,:))'))>=1e-6;           % Tolerance
+    dir = -dir;
+    %[x,~,~] = solveLP(dir*obj.G,[],[],Aeq,beq,lb,ub,optSolver);
+    x = findVertex(dir,obj.G,Aeq,beq,lb,ub,optSolver);
+    extreme(2,:) = [obj.G*x + obj.c]';
+    isNewVert(2) = sum(abs(nullDirs*(extreme(2,:)-foundVerts(1,:))'))>=1e-6;           % Tolerance
+    dir = nullDirs(2,:);
+    %[x,~,~] = solveLP(dir*obj.G,[],[],Aeq,beq,lb,ub,optSolver);
+    x = findVertex(dir,obj.G,Aeq,beq,lb,ub,optSolver);
+    extreme(3,:) = [obj.G*x + obj.c]';
+    isNewVert(3) = sum(abs(nullDirs*(extreme(3,:)-foundVerts(1,:))'))>=1e-6;           % Tolerance
+    dir = -dir;
+    %[x,~,~] = solveLP(dir*obj.G,[],[],Aeq,beq,lb,ub,optSolver);
+    x = findVertex(dir,obj.G,Aeq,beq,lb,ub,optSolver);
+    extreme(4,:) = [obj.G*x + obj.c]';
+    isNewVert(4) = sum(abs(nullDirs*(extreme(4,:)-foundVerts(1,:))'))>=1e-6;           % Tolerance
+    if max(isNewVert) == 0  % A line segment in 3D
+        v = foundVerts;
+        f = [1 2];
+        return
+    end
 
-% Continue if set is not a line segment in 3D
-indxPairs = [1 2; 1 3; 1 4; 2 3; 2 4; 3 4];
-coPlanar = zeros(6,1);
-for i = 1:6
-    coPlanar(i) = abs(det([foundVerts(2,:)-foundVerts(1,:);extreme(indxPairs(i,1),:)-foundVerts(1,:);extreme(indxPairs(i,2),:)-foundVerts(1,:)])) <= 1e-6;
-end
-if min(coPlanar) == 1 % A planar set in 3D
-    indx = find(isNewVert,1);
-%     basis = orth([foundVerts(2,:)-foundVerts(1,:);extreme(indx,:)-foundVerts(1,:)]')';
-%     reducedG = basis*obj.G;
-    normVec = cross(foundVerts(2,:)-foundVerts(1,:),extreme(indx,:)-foundVerts(1,:));
-    reducedG = obj.G(1:2,:); % Will not work if set is 'vertical';
-    reducedObj = conZono(reducedG,obj.c(1:2),obj.A,obj.b);
-    optPlot = plotOptions('Display','off');
-    optPlot.SolverOpts = optSolver;
-    [reducedV,~] = plot(reducedObj,optPlot);
-%     v = obj.c' + reducedV*basis;
-    v = [reducedV 1/normVec(3)*(normVec*foundVerts(1,:)'-sum(normVec(1:2).*reducedV,2))];
-    f = [1:size(v,1)];
-    return
-end
+    % Continue if set is not a line segment in 3D
+    indxPairs = [1 2; 1 3; 1 4; 2 3; 2 4; 3 4];
+    coPlanar = zeros(6,1);
+    for i = 1:6
+        coPlanar(i) = abs(det([foundVerts(2,:)-foundVerts(1,:);extreme(indxPairs(i,1),:)-foundVerts(1,:);extreme(indxPairs(i,2),:)-foundVerts(1,:)])) <= 1e-6;
+    end
+    if min(coPlanar) == 1 % A planar set in 3D
+        indx = find(isNewVert,1);
+    %     basis = orth([foundVerts(2,:)-foundVerts(1,:);extreme(indx,:)-foundVerts(1,:)]')';
+    %     reducedG = basis*obj.G;
+        normVec = cross(foundVerts(2,:)-foundVerts(1,:),extreme(indx,:)-foundVerts(1,:));
+        reducedG = obj.G(1:2,:); % Will not work if set is 'vertical';
+        reducedObj = conZono(reducedG,obj.c(1:2),obj.A,obj.b);
+        optPlot = plotOptions('Display','off');
+        optPlot.SolverOpts = optSolver;
+        [reducedV,~] = plot(reducedObj,optPlot);
+    %     v = obj.c' + reducedV*basis;
+        v = [reducedV 1/normVec(3)*(normVec*foundVerts(1,:)'-sum(normVec(1:2).*reducedV,2))];
+        f = [1:size(v,1)];
+        return
+    end
 
-% Continue if set is not a 2D planar set in 3D
-% Form 3-simplex
-% indx = find(isNewVert,1);
-% foundVerts(3,:) = extreme(indx,:);
-% indx = find(coPlanar==0,1); 
-% foundVerts(4,:) = extreme(indx+1,:);
-indx = find(coPlanar==0,1);
-foundVerts(3,:) = extreme(indxPairs(indx,1),:);
-foundVerts(4,:) = extreme(indxPairs(indx,2),:);
-% Interior point
-interiorPoint = sum(foundVerts(1:4,:))/4;
-% Faces, vertices, and normals
-[f] = nchoosek(1:4,3);
-fNorms = zeros(0,3);
-for i = 1:size(f,1)
-    [fN,fC] = faceNormal(foundVerts(f(i,1:3),:),interiorPoint);
-    fNorms(i,:)= fN;
-end
-% Expand polytope
-maxIter = 1e6;                                      % Maximium iterations
-fIndex = 1;
-nVerts = 4;
-for i = 1:maxIter
-    [dir,~] = faceNormal(foundVerts(f(fIndex,1:3),:),interiorPoint);
-    [x,~,~] = solveLP(dir*obj.G,[],[],Aeq,beq,lb,ub,optSolver);
-    extreme = [obj.G*x + obj.c]';
-    [foundVerts,isNew] = addIfNew(foundVerts,extreme,dir);
-    if isNew
-        nVerts = nVerts + 1;
-        % Find all faces that see the new vertex
-        facesThatSee = findFacesThatSeeNewVertex(fNorms,foundVerts(f(:,1),:),extreme);
-        sharedEdges = findSharedEdges(find(facesThatSee),f);
-        facesToRemove = [];
-        for indx = find(facesThatSee)
-            removeCurrentFace = 0;
-            if ismember(nVerts,f(indx,:))
-                continue
-            end
-            nVertsRow = find(f(indx,:),1,'last');
-            startVerts = f(indx,1:nVertsRow);
-            endVerts = [f(indx,2:nVertsRow) f(indx,1)];
-            allCombos = [startVerts' endVerts'];
-            allCombos = setdiff(sort(allCombos,2),sort(sharedEdges,2),'rows'); 
-            newFaces = [allCombos nVerts*ones(size(allCombos,1),1)];
-            minIndices = [];
-            if isempty(newFaces)
-                removeCurrentFace = 1;
-            end
-            for j = 1:size(newFaces,1)
-                [fN,~] = faceNormal(foundVerts(newFaces(j,1:3),:),interiorPoint);
-                [minVal,minIndx] = min(sum(abs(fNorms-fN),2));
-                isNewFace = minVal>=1e-12;                    % Tolerance (Changed, 1e-6 too small => errors)
-                if isNewFace % Create new face
-                    fNorms = [fNorms;fN];
-                    f = [f;newFaces(j,:) zeros(1,size(f,2)-3)];
+    % Continue if set is not a 2D planar set in 3D
+    % Form 3-simplex
+    % indx = find(isNewVert,1);
+    % foundVerts(3,:) = extreme(indx,:);
+    % indx = find(coPlanar==0,1); 
+    % foundVerts(4,:) = extreme(indx+1,:);
+    indx = find(coPlanar==0,1);
+    foundVerts(3,:) = extreme(indxPairs(indx,1),:);
+    foundVerts(4,:) = extreme(indxPairs(indx,2),:);
+    % Interior point
+    interiorPoint = sum(foundVerts(1:4,:))/4;
+    % Faces, vertices, and normals
+    [f] = nchoosek(1:4,3);
+    fNorms = zeros(0,3);
+    for i = 1:size(f,1)
+        [fN,fC] = faceNormal(foundVerts(f(i,1:3),:),interiorPoint);
+        fNorms(i,:)= fN;
+    end
+    % Expand polytope
+    maxIter = 1e6;                                      % Maximium iterations
+    fIndex = 1;
+    nVerts = 4;
+    for i = 1:maxIter
+        [dir,~] = faceNormal(foundVerts(f(fIndex,1:3),:),interiorPoint);
+        %[x,~,~] = solveLP(dir*obj.G,[],[],Aeq,beq,lb,ub,optSolver);
+        x = findVertex(dir,obj.G,Aeq,beq,lb,ub,optSolver);
+        extreme = [obj.G*x + obj.c]';
+        [foundVerts,isNew] = addIfNew(foundVerts,extreme,dir);
+        if isNew
+            nVerts = nVerts + 1;
+            % Find all faces that see the new vertex
+            facesThatSee = findFacesThatSeeNewVertex(fNorms,foundVerts(f(:,1),:),extreme);
+            sharedEdges = findSharedEdges(find(facesThatSee),f);
+            facesToRemove = [];
+            for indx = find(facesThatSee)
+                removeCurrentFace = 0;
+                if ismember(nVerts,f(indx,:))
+                    continue
+                end
+                nVertsRow = find(f(indx,:),1,'last');
+                startVerts = f(indx,1:nVertsRow);
+                endVerts = [f(indx,2:nVertsRow) f(indx,1)];
+                allCombos = [startVerts' endVerts'];
+                allCombos = setdiff(sort(allCombos,2),sort(sharedEdges,2),'rows'); 
+                newFaces = [allCombos nVerts*ones(size(allCombos,1),1)];
+                minIndices = [];
+                if isempty(newFaces)
                     removeCurrentFace = 1;
-                else % Combine with existing face
-                    if ~ismember(nVerts,f(minIndx,:))
-                        minIndices = [minIndices;minIndx];
-                        n = find(f(minIndx,:),1,'last');
-                        if n + 1 > size(f,2)
-                            f = [f zeros(size(f,1),1)];
-                        end
-                        f(minIndx,n+1) = nVerts;
-                        f(minIndx,:) = reOrderVerts(f(minIndx,:),foundVerts,interiorPoint);
+                end
+                for j = 1:size(newFaces,1)
+                    [fN,~] = faceNormal(foundVerts(newFaces(j,1:3),:),interiorPoint);
+                    [minVal,minIndx] = min(sum(abs(fNorms-fN),2));
+                    isNewFace = minVal>=1e-12;                    % Tolerance (Changed, 1e-6 too small => errors)
+                    if isNewFace % Create new face
+                        fNorms = [fNorms;fN];
+                        f = [f;newFaces(j,:) zeros(1,size(f,2)-3)];
                         removeCurrentFace = 1;
+                    else % Combine with existing face
+                        if ~ismember(nVerts,f(minIndx,:))
+                            minIndices = [minIndices;minIndx];
+                            n = find(f(minIndx,:),1,'last');
+                            if n + 1 > size(f,2)
+                                f = [f zeros(size(f,1),1)];
+                            end
+                            f(minIndx,n+1) = nVerts;
+                            f(minIndx,:) = reOrderVerts(f(minIndx,:),foundVerts,interiorPoint);
+                            removeCurrentFace = 1;
+                        end
                     end
                 end
+                if removeCurrentFace && ~ismember(indx,minIndices)
+                    facesToRemove = [facesToRemove; indx];
+                end
             end
-            if removeCurrentFace && ~ismember(indx,minIndices)
-                facesToRemove = [facesToRemove; indx];
-            end
+            f(facesToRemove,:) = [];
+            fNorms(facesToRemove,:) = [];
+        else
+            fIndex = fIndex + 1;
         end
-        f(facesToRemove,:) = [];
-        fNorms(facesToRemove,:) = [];
-    else
-        fIndex = fIndex + 1;
+        if fIndex > size(f,1)
+            break
+        end   
     end
-    if fIndex > size(f,1)
-        break
-    end   
+    v = foundVerts;
+    f(f==0) = nan;
+catch E
+    if strcmp(E.identifier, 'PlotError:VertexNotFound')
+        if checkEmpty(conZono(obj.G,obj.c,Aeq,beq))
+            warning('zonoLAB:EmptyZonotope','Constrained zonotope is empty and cannot be plotted.')
+            v = []; f = [];
+            return
+        end
+        rethrow(E);
+    else
+        rethrow(E);
+    end
 end
-v = foundVerts;
-f(f==0) = nan;
 
 end
 
 % Local Functions
+function [x] = findVertex(dir,G,Aeq,beq,lb,ub,optSolver)
+    [x,~,~] = solveLP(dir*G,[],[],Aeq,beq,lb,ub,optSolver);
+    if isnan(x)
+        error('PlotError:VertexNotFound','Could not find a solution for a vertex while plotting')
+    end
+end
+
 function [foundVerts,isNew] = addIfNew(foundVerts,extreme,dir)
     isNew = 0;
     % Check if this is the first found vertex

--- a/@hybZono/getLeaves.m
+++ b/@hybZono/getLeaves.m
@@ -27,7 +27,7 @@ if isempty(obj.b)
 end
 
 % Continue if set has equality constraints
-if isempty(optSolver)
+if nargin < 2 || isempty(optSolver)
     optSolver = solverOptions;
 end
 

--- a/@hybZono/plotAsConZono.m
+++ b/@hybZono/plotAsConZono.m
@@ -22,7 +22,9 @@ function [v,f] = plotAsConZono(obj,optSolver)
 % Determine number of non-empty constrained zonotopes
 [leaves] = getLeaves(obj,optSolver);
 if isempty(leaves)
-    error('Empty set.')
+    warning('zonoLAB:EmptyZonotope','Hybrid zonotope is empty and cannot be plotted.')
+    v = []; f = [];
+    return
 end
 nLeaves = size(leaves,2);
 
@@ -34,9 +36,13 @@ waitbarHandle = waitbar(0,['Plotting hybrid zonotope with ',num2str(nLeaves),' l
 %  If \xib denotes the i^th column of leaves, then the corresponding
 %  non-empty constrained zonotope is of the form:
 %  Z = { (c + Gb \xib) + Gc \xic | ||\xic||_inf <= 1, Ac \xi = b - Ab \xib }
+emptyLeaves = false;
 for i = 1:nLeaves
     Zi = conZono(obj.Gc,obj.c+obj.Gb*leaves(:,i),obj.Ac,obj.b-obj.Ab*leaves(:,i));
     [vi,fi] = plot(Zi,optPlot);
+    if size(vi,1) == 0
+        emptyLeaves = true;
+    end
     nVerts(i) = size(vi,1);
     v = [v;vi];
     if size(fi,2) > size(f,2)
@@ -49,5 +55,10 @@ for i = 1:nLeaves
     waitbar(i/nLeaves,waitbarHandle)
 end
 close(waitbarHandle)
+
+% Check for unplotted conZono leaves
+if emptyLeaves
+    warning('zonoLAB:Tolerance','Some leaves of the hybrid zonotope did not plot and may be caused by constraints that are nearly redundant (close to the plotting/optimization tolerances). Check the validity of other leaves.')
+end
 
 end

--- a/dev/Test_Plotting_Tolerance.m
+++ b/dev/Test_Plotting_Tolerance.m
@@ -1,0 +1,48 @@
+clc;
+clf;
+clear;
+n = 2; % 2 or 3
+zono_type = 'hybZono';
+% zono_type = 'conZono';
+
+fprintf('Plot 1:\n')
+% Zonotope with redundant constraints
+subplot(2,2,1);
+if strcmp(zono_type,'hybZono')
+    Z = hybZono(eye(n),zeros(n,1),zeros(n,1),ones(2,n),ones(2,1),[0;0]);
+else
+    Z = conZono(eye(n),zeros(n,1),ones(2,n),[0;0]);
+end
+plot(Z,'b',0.8)
+title('b = [0;0]')
+axis(repmat([-1 1],1,n))
+
+fprintf('------------------------\n')
+fprintf('Plot 2:\n')
+% Same zonotope but made infeasible by adjusting b above the tolerance level
+% Perceived as infeasible
+subplot(2,2,2);
+Z.b(2) = 1e-4;
+plot(Z,'b',0.8)
+title('b = [0;1e-4]')
+axis(repmat([-1 1],1,n))
+
+fprintf('------------------------\n')
+fprintf('Plot 3:\n')
+% Same zonotope but made infeasible by adjusting b near the tolerance level
+% One leaf is perceived as infeasible
+subplot(2,2,3);
+Z.b(2) = 1e-6;
+[v,f]=plot(Z,'b',0.8);
+title('b = [0;1e-6]')
+axis(repmat([-1 1],1,n))
+
+fprintf('------------------------\n')
+fprintf('Plot 4:\n')
+% Same zonotope but made infeasible by adjusting b below the tolerance level
+% Perceived as redundant constraints
+subplot(2,2,4);
+Z.b(2) = 1e-7;
+plot(Z,'b',0.8)
+title('b = [0;1e-7]')
+axis(repmat([-1 1],1,n))

--- a/globalFunctions/hPoly2conZono.m
+++ b/globalFunctions/hPoly2conZono.m
@@ -27,9 +27,15 @@ for i = 1:n
     dir(i) = 1;
     % Find upper bounds
     [x,~,~] = solveLP(dir,H,f,[],[],-realmax*ones(n,1),realmax*ones(n,1),[]);
+    if isnan(x)
+        error('H-rep is infeasible.')
+    end
     upperBounds(i) = x(i);
     % Find lower bounds
     [x,~,~] = solveLP(-dir,H,f,[],[],-realmax*ones(n,1),realmax*ones(n,1),[]);
+    if isnan(x)
+        error('H-rep is infeasible.')
+    end
     lowerBounds(i) = x(i);
 end
 

--- a/globalFunctions/solveLP.m
+++ b/globalFunctions/solveLP.m
@@ -48,9 +48,15 @@ switch optSolver.lpSolver
         params.Threads = 1;
         params.outputflag = 0;
         result = gurobi(model,params);
-        x = result.x;
-        fVal = result.objval;
         exitFlag = result.status;
+        x = NaN;
+        fVal = NaN;
+        if strcmp(exitFlag,'OPTIMAL')
+            x = result.x;
+            fVal = result.objval;
+        else
+            warning('Linear program did not find an optimal solution.');
+        end
     otherwise
         error('Only linprog (default) and gurobi are options for solving LPs.')
 end


### PR DESCRIPTION
This pull request provides error catching for plotting, mainly so that complex hybrid zonotopes can continue to plot even if a few constrained zonotope leaves are empty. This mainly appears to happen when the getLeaves function does not identify the conzono set as empty due to different tolerances being used.  I've added a test script in \dev to demonstrate this and test the error catching.

As this includes solving linear programs, the changes also modify the solveLP function to "fail" more gracefully.

In general the approach taken uses warnings to notify the user when optimization solutions cannot be found and when zonotopes are empty (as opposed to throwing errors). 