### PR TITLE
Fixed Gurobi 13 solution-pool field compatibility

### DIFF
--- a/globalFunctions/solveMILP.m
+++ b/globalFunctions/solveMILP.m
@@ -79,7 +79,12 @@ switch optSolver.milpSolver
             	return
             end
 
-            x = [result.pool.xn];
+            if isfield(result.pool, 'poolnx')
+                % Gurobi 13.0 and newer
+                x = [result.pool.poolnx];
+            elseif isfield(result.pool, 'xn')
+                x = [result.pool.xn];
+            end
             fVal = [result.pool.objval];
         end
         exitFlag = result.status;


### PR DESCRIPTION
## Summary

Gurobi 13 renamed the MATLAB solution-pool field from `xn` to `poolnx` (see [here](https://docs.gurobi.com/projects/optimizer/en/13.0/reference/releasenotes/changes.html#changes-to-matlab-api)). As a result, requesting multiple MILP solutions currently produces:

    Unrecognized field name "xn".

This updates `solveMILP` to use `poolnx` when available while retaining support for the older `xn` field.

## Testing

Tested with:

- MATLAB: R2026a
- Gurobi: 13.0
- `optSolver.nSolutions > 1`

The change resolves the error and returns the solution pool correctly.